### PR TITLE
Update ProductController.php

### DIFF
--- a/src/app/code/community/Flagbit/ChangeAttributeSet/controllers/Adminhtml/Catalog/ProductController.php
+++ b/src/app/code/community/Flagbit/ChangeAttributeSet/controllers/Adminhtml/Catalog/ProductController.php
@@ -82,4 +82,13 @@ class Flagbit_ChangeAttributeSet_Adminhtml_Catalog_ProductController extends Mag
         return count($attributesMatchingInNewAttributeSet) === 0;
     }
 
+    /**
+     * Check admin permissions for this controller.
+     * This allows a user to change the attribute set if they are allowed to edit products.
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('catalog/products');
+    }
+
 }


### PR DESCRIPTION
Add permission necessary after SUPEE-6285 patch so that the user can change the attribute set if they are allowed to edit products.

This fixes issue #5 

Some may desire a different permission other than catalog/products? This one works for me as in my setting if anyone can edit products, it is OK to change the attribute set, but others may have different requirements or want a completely separate permission, I'm not sure.