### PR TITLE
Removed newline that made the content unreadable

### DIFF
--- a/src/app/code/community/Flagbit/ChangeAttributeSet/etc/config.xml
+++ b/src/app/code/community/Flagbit/ChangeAttributeSet/etc/config.xml
@@ -46,8 +46,7 @@
             <adminhtml>
                 <args>
                     <modules>
-                        <Flagbit_ChangeAttributeSet before="Mage_Adminhtml">Flagbit_ChangeAttributeSet_Adminhtml
-                        </Flagbit_ChangeAttributeSet>
+                        <Flagbit_ChangeAttributeSet before="Mage_Adminhtml">Flagbit_ChangeAttributeSet_Adminhtml</Flagbit_ChangeAttributeSet>
                     </modules>
                 </args>
             </adminhtml>


### PR DESCRIPTION
The newline in the config xml for adding the admin route made the parsing of the content faulty. The route was not read correctly and the route did not work. By removing the newline the route worked again.