### PR TITLE
Fix: get correct attribute IDs to delete

### DIFF
--- a/src/app/code/community/Flagbit/ChangeAttributeSet/controllers/Adminhtml/Catalog/ProductController.php
+++ b/src/app/code/community/Flagbit/ChangeAttributeSet/controllers/Adminhtml/Catalog/ProductController.php
@@ -67,17 +67,13 @@ class Flagbit_ChangeAttributeSet_Adminhtml_Catalog_ProductController extends Mag
                         ->setAttributeSetFilter($attributeSet)
                         ->getColumnValues('attribute_id');
 
-                    $allAttributes = Mage::getResourceModel('catalog/product_attribute_collection')
-                        ->getColumnValues('attribute_id');
-
-                    $attributesToDelete = array_diff($allAttributes, $targetAttributes);
                     if (count($attributesToDelete)) {
                         $resource = Mage::getSingleton('core/resource');
                         $write = $resource->getConnection('core_write');
 
                         $condition = array(
                             $write->quoteInto('entity_id IN (?)', $productIds),
-                            $write->quoteInto('attribute_id IN (?)', $attributesToDelete),
+                            $write->quoteInto('attribute_id NOT IN (?)', $targetAttributes),
                         );
 
                         foreach ($this->_getDeleteFromTables() as $table) {

--- a/src/app/code/community/Flagbit/ChangeAttributeSet/controllers/Adminhtml/Catalog/ProductController.php
+++ b/src/app/code/community/Flagbit/ChangeAttributeSet/controllers/Adminhtml/Catalog/ProductController.php
@@ -65,25 +65,19 @@ class Flagbit_ChangeAttributeSet_Adminhtml_Catalog_ProductController extends Mag
                 if ($deleteFlag) {
                     $targetAttributes = Mage::getResourceModel('catalog/product_attribute_collection')
                         ->setAttributeSetFilter($attributeSet)
-                        ->getColumnValues('attribute_code');
+                        ->getColumnValues('attribute_id');
 
                     $allAttributes = Mage::getResourceModel('catalog/product_attribute_collection')
-                        ->getColumnValues('attribute_code');
+                        ->getColumnValues('attribute_id');
 
                     $attributesToDelete = array_diff($allAttributes, $targetAttributes);
                     if (count($attributesToDelete)) {
                         $resource = Mage::getSingleton('core/resource');
-                        $read = $resource->getConnection('core_read');
                         $write = $resource->getConnection('core_write');
-
-                        $query = $read->select()
-                            ->from($resource->getTableName('eav_attribute'), array('attribute_id'))
-                            ->where('attribute_code IN (?)', $attributesToDelete);
-                        $attributeIds = $read->fetchCol($query, 'attribute_id');
 
                         $condition = array(
                             $write->quoteInto('entity_id IN (?)', $productIds),
-                            $write->quoteInto('attribute_id IN (?)', $attributeIds),
+                            $write->quoteInto('attribute_id IN (?)', $attributesToDelete),
                         );
 
                         foreach ($this->_getDeleteFromTables() as $table) {


### PR DESCRIPTION
Can't remember why I've used `attribute_code` to find orphan records, but it makes no sense.

Additionally this query gave a wrong result, because it also contains attribute IDs from category attributes (like name, meta_description, ...) .

```
$query = $read->select()
    ->from($resource->getTableName('eav_attribute'), array('attribute_id'))
    ->where('attribute_code IN (?)', $attributesToDelete);
$attributeIds = $read->fetchCol($query, 'attribute_id');
```

It had no impact because category attribute IDs are not in `catelog_product_entity` tables, but its obviously wrong.
